### PR TITLE
fix: no duplicate header when default header used

### DIFF
--- a/MMM-HolidayCountdown.js
+++ b/MMM-HolidayCountdown.js
@@ -32,10 +32,12 @@ Module.register("MMM-HolidayCountdown", {
         var wrapper = document.createElement("div");
         wrapper.className = "holiday-countdown";  // Ensure this class name is correct
 
-        var header = document.createElement("header");
-		// Use header from config if set, otherwise fall back to default
-		header.innerHTML = this.config.header || this.defaults.header;
-		wrapper.appendChild(header);
+		if(this.config.header || this.defaults.header) {
+	        var header = document.createElement("header");
+			// Use header from config if set, otherwise fall back to default
+			header.innerHTML = this.config.header || this.defaults.header;
+			wrapper.appendChild(header);
+		}
 
         // Get the current date and zero out the time portion
         var today = new Date();


### PR DESCRIPTION
I want to use the default Module header which has the same style everywhere, but currently can't, because it's renders the Module's inner header anyway:

<img width="270" height="99" alt="image" src="https://github.com/user-attachments/assets/521a064f-5901-4f5c-a93e-e9bb2c604b2b" />

My config:
```
        {
                module: "MMM-HolidayCountdown",
                header: "Holiday Countdown",
                position: "bottom_right",  // Or wherever you'd like it displayed
                config: {
                        trips: [
                                { destination: "Karácsony", date: "2025-12-24" },
                        ]
                }
        },
```

Solution: Conditional rendering the header element only when needed.

Docs for the default configs: https://docs.magicmirror.builders/modules/configuration.html