### PR TITLE
Add the ability to include today in the days counted

### DIFF
--- a/MMM-HolidayCountdown.js
+++ b/MMM-HolidayCountdown.js
@@ -10,6 +10,7 @@
 
 Module.register("MMM-HolidayCountdown", {
     defaults: {
+        include_today: false,
         trips: [
             { destination: "Tunisia", date: "2024-02-15" },
             { destination: "Reighton Sands", date: "2023-11-01" },

--- a/MMM-HolidayCountdown.js
+++ b/MMM-HolidayCountdown.js
@@ -67,7 +67,7 @@ Module.register("MMM-HolidayCountdown", {
             var tripDate = new Date(trip.date);
             tripDate.setHours(0, 0, 0, 0);  // Zero out time portion for the trip date
 
-            var daysRemaining = Math.floor((tripDate - today) / (1000 * 60 * 60 * 24));
+            var daysRemaining = (Math.floor((tripDate - today) / (1000 * 60 * 60 * 24))) + Number(this.config.include_today);
 
             var daysElement = document.createElement("div");
             daysElement.className = "days";

--- a/config.js-Example.txt
+++ b/config.js-Example.txt
@@ -10,6 +10,7 @@ Example config.js should look like
     position: "top_left",  // Or wherever you'd like it displayed
     config: {
         header: "Holiday Countdown",
+        include_today: false, // true|false - False keeps the default behavior
         trips: [
             { destination: "Tunisia", date: "2023-08-15" },
             { destination: "Reighton Sands", date: "2022-11-01" }


### PR DESCRIPTION
When I added birthdays or holidays to the module, I would get -1 day in days remaining if I included today. 
For example, if I have a trip configured as: `{ destination: "New Year 2026", date: "2026-01-01" }`, today (December 26th, 2025) the default behavior shows 5 days remaining (27, 28, 29, 30, 31). 

However, I want the module to include today as part of the remaining days, so I added a new configuration parameter: `include_today`. If the configuration parameter is not provided in the `config.js` of MM, the default behavior will be used (today will not be counted).

When this parameters is configured as `true`, today will be counted as a remaining day. In the scenario above, it would show 6 days remaining (26, 27, 28, 29, 30, 31).

The new configuration would look like this: 
``` yaml
config: {
  header: "Upcoming holidays",
  include_today: true,
       trips: [
  { destination: "Dad's birthday", date: "2026-02-23" },
  { destination: "Child's birthday", date: "2026-05-17" },
  { destination: "Mom's birthday", date: "2026-06-21" },
  { destination: "Grandma's birthday", date: "2026-12-05" },
  ]
}
```